### PR TITLE
Patch fo detecting multiply symbols between encoding and closing xml …

### DIFF
--- a/src/exemel.erl
+++ b/src/exemel.erl
@@ -42,7 +42,7 @@ prepare_test_() ->
       ?_test(
         begin
           {ok, Data} = file:read_file("../priv/rus.xml"),
-          ?assertEqual("\r\n<Name>Австралийский доллар</Name>\r\n", prepare(binary_to_list(Data)))
+          ?assertEqual("\r\n<Name>Австралийский доллар</Name>\r\n", lists:flatten(io_lib:format("~ts",[list_to_binary(prepare(binary_to_list(Data)))]))) 
         end
       )
     ]

--- a/src/exemel.erl
+++ b/src/exemel.erl
@@ -42,7 +42,7 @@ prepare_test_() ->
       ?_test(
         begin
           {ok, Data} = file:read_file("../priv/rus.xml"),
-          ?assertEqual("\r\n<Name>Австралийский доллар</Name>\r\n", lists:flatten(io_lib:format("~ts",[list_to_binary(prepare(binary_to_list(Data)))]))) 
+          ?assertEqual(binary_to_list(unicode:characters_to_binary("\r\n<Name>Австралийский доллар</Name>\r\n")), prepare(binary_to_list(Data)))
         end
       )
     ]

--- a/src/exemel_encoding.erl
+++ b/src/exemel_encoding.erl
@@ -5,7 +5,7 @@
 %% API
 -export([detect/2, detect/1]).
 
--define(ENCONING_RE, "^\\<\\?xml.+?encoding=\"([^\"]+)\".+?\\?\\>").
+-define(ENCONING_RE, "^\\<\\?xml.+?encoding=\"([^\"]+)\".*?\\?\\>").
 
 detect(Data, Default) ->
   case re:run(Data, ?ENCONING_RE) of

--- a/src/exemel_encoding.erl
+++ b/src/exemel_encoding.erl
@@ -30,6 +30,9 @@ detection_test_() ->
   [
     ?_assertEqual(#encoding_info{name = "utf-8", offset = 0}, detect("", "utf-8")),
     ?_assertEqual(#encoding_info{name = "windows-1251", offset = 32}, detect("<?xml encoding=\"windows-1251\" ?>", "utf-8")),
+    ?_assertEqual(#encoding_info{name = "windows-1251", offset = 45}, detect("<?xml version=\"1.0\" encoding=\"windows-1251\"?>")),
+    ?_assertEqual(#encoding_info{name = "windows-1251", offset = 46}, detect("<?xml version=\"1.0\" encoding=\"windows-1251\" ?>")),
+    ?_assertEqual(#encoding_info{name = "windows-1251", offset = 47}, detect("<?xml version=\"1.0\" encoding=\"windows-1251\"  ?>")),
     ?_assertEqual(#encoding_info{name = "koi8r", offset = 25}, detect("<?xml encoding=\"koi8r\" ?>")),
     ?_assertMatch(#encoding_info{name = "koi8r"}, detect("<?xml version=\"1.0\" encoding=\"koi8r\" ?>")),
     ?_assertMatch(#encoding_info{name = "koi8r"}, detect("<?xml encoding=\"koi8r\" version=\"1.0\"?>"))

--- a/test/xmerl_integration_test.erl
+++ b/test/xmerl_integration_test.erl
@@ -30,10 +30,10 @@ prepared_xmerl_test_() ->
             Parsed
           ),
           [Content] = Parsed#xmlElement.content,
-          Text = <<"Австралийский доллар">>,
+          Text = "Австралийский доллар",
           ?assertEqual(
             Text,
-            unicode:characters_to_binary(Content#xmlText.value, unicode)
+            Content#xmlText.value
           )
         end
       )


### PR DESCRIPTION
…preprocessor command

For example <?xml version="1.0" encoding="windows-1251" ?>. See extra space between "windows-1251"  and ?>
